### PR TITLE
Patch for testOutputDirectory

### DIFF
--- a/src/main/java/com/mysema/maven/apt/AbstractProcessorMojo.java
+++ b/src/main/java/com/mysema/maven/apt/AbstractProcessorMojo.java
@@ -41,11 +41,6 @@ public abstract class AbstractProcessorMojo extends AbstractMojo {
     protected MavenProject project;
 
     /**
-     * @parameter 
-     */
-    protected File outputDirectory;
-
-    /**
      * @parameter
      */
     protected String[] processors;
@@ -143,8 +138,8 @@ public abstract class AbstractProcessorMojo extends AbstractMojo {
 
     @SuppressWarnings("unchecked")
     public void execute() throws MojoExecutionException {                    
-        if (outputDirectory != null && !outputDirectory.exists()) {
-            outputDirectory.mkdirs();
+        if (getOutputDirectory() != null && !getOutputDirectory().exists()) {
+            getOutputDirectory().mkdirs();
         }        
         try {
             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -174,8 +169,8 @@ public abstract class AbstractProcessorMojo extends AbstractMojo {
                 }
             }
             
-            if (outputDirectory != null){
-                compilerOpts.put("s", outputDirectory.getPath());    
+            if (getOutputDirectory() != null){
+                compilerOpts.put("s", getOutputDirectory().getPath());
             }
             
             if (!showWarnings) {
@@ -212,11 +207,11 @@ public abstract class AbstractProcessorMojo extends AbstractMojo {
                 getLog().error(out.toString());
             }
 
-            if (outputDirectory != null){
+            if (getOutputDirectory() != null){
                 if (isForTest()){
-                    project.addTestCompileSourceRoot(outputDirectory.getAbsolutePath());                
+                    project.addTestCompileSourceRoot(getOutputDirectory().getAbsolutePath());
                 }else{
-                    project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
+                    project.addCompileSourceRoot(getOutputDirectory().getAbsolutePath());
                 }    
             }
             
@@ -229,6 +224,8 @@ public abstract class AbstractProcessorMojo extends AbstractMojo {
     }
 
     protected abstract File getSourceDirectory();
+
+    protected abstract File getOutputDirectory();
 
     protected boolean isForTest(){
         return false;

--- a/src/main/java/com/mysema/maven/apt/AnnotationProcessorMojo.java
+++ b/src/main/java/com/mysema/maven/apt/AnnotationProcessorMojo.java
@@ -17,10 +17,19 @@ import java.io.File;
 public class AnnotationProcessorMojo extends AbstractProcessorMojo {
 
     /**
+     * @parameter
+     */
+    protected File outputDirectory;
+
+    /**
      * @parameter expression="${project.build.sourceDirectory}" required=true
      */
     protected File sourceDirectory;
-  
+
+    @Override
+    public File getOutputDirectory() {
+        return outputDirectory;
+    }
 
     @Override
     protected File getSourceDirectory() {

--- a/src/main/java/com/mysema/maven/apt/TestAnnotationProcessorMojo.java
+++ b/src/main/java/com/mysema/maven/apt/TestAnnotationProcessorMojo.java
@@ -17,10 +17,25 @@ import java.io.File;
 public class TestAnnotationProcessorMojo extends AbstractProcessorMojo {
 
     /**
+     * @parameter
+     */
+    protected File outputDirectory;
+
+    /**
+     * @parameter
+     */
+    protected File testOutputDirectory;
+
+    /**
      * @parameter expression="${project.build.testSourceDirectory}" required=true
      */
     protected File sourceDirectory;
   
+    @Override
+    public File getOutputDirectory() {
+        return testOutputDirectory != null ? testOutputDirectory : outputDirectory;
+    }
+
     @Override
     protected File getSourceDirectory() {
         return sourceDirectory;


### PR DESCRIPTION
This patch allows you to have separate output directories for apt:process and apt:test-process. This is especially useful when you want to store generated files in your VCS and re-generate them manually, so you cannot use separate &lt;executions/&gt; with custom configuration.
