### PR TITLE
Bugfix 9: Target folder not imported to classpath with m2e

### DIFF
--- a/src/test/java/com/mysemna/maven/apt/AnnotationProcessorMojoTest.java
+++ b/src/test/java/com/mysemna/maven/apt/AnnotationProcessorMojoTest.java
@@ -41,7 +41,7 @@ public class AnnotationProcessorMojoTest {
         Log log = EasyMock.createMock(Log.class);
         BuildContext buildContext = new DefaultBuildContext();
         project = EasyMock.createMock(MavenProject.class); 
-        List sourceRoots = Lists.newArrayList("src/test/resources/project-to-test/src/main/java");
+        List sourceRoots = Lists.newArrayList("src/test/resources/project-to-test/src/main/java", "notExisting/sourceRoot/folder");
         URLClassLoader loader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
         List classpath = ClassPathUtils.getClassPath(loader);
         EasyMock.expect(project.getCompileSourceRoots()).andReturn(sourceRoots);


### PR DESCRIPTION
Fixes https://github.com/mysema/maven-apt-plugin/issues/9

Automaticaly add outputFolder as eclipse sourceFolder during maven
project configuration update - same behaviour as
build-helper-maven-plugin and therefor it is no longer needed.

Not existing source folder will not cause build to break. So you can declare plugin in your parent pom for all projects that need to generate sources.

Also fileManger is now correctly closed which might avoid potential resource leakage during incremental build.
